### PR TITLE
fix: optimize beatmap parsing

### DIFF
--- a/src/Services/Entities/AllTimesData/index.ts
+++ b/src/Services/Entities/AllTimesData/index.ts
@@ -1,7 +1,7 @@
 import { DataRepo } from '@/Services/repo';
+import { wLogger } from '@/logger';
 
 import { AbstractEntity } from '../types';
-import { wLogger } from '@/logger';
 
 export class AllTimesData extends AbstractEntity {
     Status: number = 0;

--- a/src/Services/Entities/BeatmapPpData/index.ts
+++ b/src/Services/Entities/BeatmapPpData/index.ts
@@ -205,13 +205,20 @@ export class BeatmapPPData extends AbstractEntity {
         const offset: number = strains.sectionLength;
         try {
             const decoder = new BeatmapDecoder();
-            const lazerBeatmap = await decoder.decodeFromPath(mapPath);
+            const lazerBeatmap = await decoder.decodeFromPath(mapPath, {
+                parseColours: false,
+                parseDifficulty: false,
+                parseEditor: false,
+                parseEvents: false,
+                parseGeneral: false,
+                parseMetadata: false
+            });
+
             this.updateBPM(lazerBeatmap.bpmMin, lazerBeatmap.bpmMax);
 
-            const firstObj =
-                lazerBeatmap.hitObjects.length > 0
-                    ? Math.round(lazerBeatmap.hitObjects.at(0)!.startTime)
-                    : 0;
+            const firstObj = Math.round(
+                lazerBeatmap.hitObjects.at(0)?.startTime ?? 0
+            );
             const full = Math.round(lazerBeatmap.totalLength);
 
             this.updateTimings(firstObj, full);
@@ -317,7 +324,7 @@ export class BeatmapPPData extends AbstractEntity {
         );
 
         wLogger.debug(`[BeatmapPpData:updateMapMetadata] updating`);
-        
+
         this.updatePPData(oldStrains, resultStrains, ppAcc as never, {
             ar: mapAttributes.ar,
             cs: mapAttributes.cs,

--- a/src/Services/Entities/GamePlayData/index.ts
+++ b/src/Services/Entities/GamePlayData/index.ts
@@ -92,14 +92,14 @@ export class GamePlayData extends AbstractEntity {
             M1Pressed: false,
             M1Count: 0,
             M2Pressed: false,
-            M2Count: 0,
+            M2Count: 0
         };
         this.isReplayUiHidden = false;
 
         // below is gata that shouldn't be reseted on retry
         if (isRetry == true) {
             return;
-        };
+        }
 
         this.isDefaultState = true;
         this.Retries = 0;
@@ -264,7 +264,9 @@ export class GamePlayData extends AbstractEntity {
 
         this.KeyOverlay = keys;
 
-        wLogger.debug(`[GamePlayData:updateKeyOverlay] updated (${rulesetAddr} ${keyOverlayArrayAddr}) ${keys.K1Count}:${keys.K2Count}:${keys.M1Count}:${keys.M2Count}`);
+        wLogger.debug(
+            `[GamePlayData:updateKeyOverlay] updated (${rulesetAddr} ${keyOverlayArrayAddr}) ${keys.K1Count}:${keys.K2Count}:${keys.M1Count}:${keys.M2Count}`
+        );
     }
 
     private getKeyOverlay(process: Process, keyOverlayArrayAddr: number) {
@@ -411,7 +413,9 @@ export class GamePlayData extends AbstractEntity {
     private updateStarsAndPerformance() {
         wLogger.debug(`[GamePlayData:updateStarsAndPerformance] starting`);
         if (!config.calculatePP) {
-            wLogger.debug(`[GamePlayData:updateStarsAndPerformance] pp calculation disabled`);
+            wLogger.debug(
+                `[GamePlayData:updateStarsAndPerformance] pp calculation disabled`
+            );
             return;
         }
 
@@ -420,7 +424,9 @@ export class GamePlayData extends AbstractEntity {
         );
 
         if (!settings.gameFolder) {
-            wLogger.debug(`[GamePlayData:updateStarsAndPerformance] game folder not found`);
+            wLogger.debug(
+                `[GamePlayData:updateStarsAndPerformance] game folder not found`
+            );
             return;
         }
 

--- a/src/Services/Entities/MenuData/index.ts
+++ b/src/Services/Entities/MenuData/index.ts
@@ -136,7 +136,7 @@ export class MenuData extends AbstractEntity {
         this.MP3Length = Math.round(
             process.readDouble(
                 process.readPointer(bases.getBase('getAudioLengthAddr') + 0x7) +
-                0x4
+                    0x4
             )
         );
     }

--- a/src/Services/Entities/ResultsScreenData/index.ts
+++ b/src/Services/Entities/ResultsScreenData/index.ts
@@ -1,8 +1,8 @@
 import { DataRepo } from '@/Services/repo';
 import { OsuMods } from '@/Utils/osuMods.types';
+import { wLogger } from '@/logger';
 
 import { AbstractEntity } from '../types';
-import { wLogger } from '@/logger';
 
 export class ResultsScreenData extends AbstractEntity {
     PlayerName: string;
@@ -25,7 +25,7 @@ export class ResultsScreenData extends AbstractEntity {
 
     init() {
         wLogger.debug(`[ResultsScreenData:init] reseting`);
-        
+
         this.PlayerName = '';
         this.Mods = 0;
         this.Mode = 0;


### PR DESCRIPTION
Currently, you are parsing unused beatmap sections, including storyboards. 
Sometimes, storyboards can be embedded directly into .osu files, causing you to spend extra time parsing beatmap.